### PR TITLE
MN-330 Billing Locations Integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,6 +113,7 @@ define(function(require) {
 		bindUploadEvents: function(template) {
 			var self = this,
 				file,
+				locationId = null, //? Billing Location Addition
 				handleFileSelect = function(evt) {
 					file = evt.target.files[0];
 					onFileSelected(file);
@@ -151,6 +152,7 @@ define(function(require) {
 								var formattedData = {
 									fileName: file.name,
 									records: results.data,
+									locationId: locationId,  //? Billing Location Addition
 									columns: {
 										expected: {
 											mandatory: self.appFlags.csvOnboarding.columns.mandatory,
@@ -172,7 +174,16 @@ define(function(require) {
 			});
 
 			template.find('#proceed').on('click', function() {
-				addJob();
+				 //? Billing Location Addition
+				self.getLocationId(function(location_id) {
+					if (locationId === false) {
+						monster.ui.alert('error', 'Billing locations experienced an issue please try again.');
+						return;
+					} else {
+						locationId = location_id;
+						addJob();
+					}
+				});
 			});
 
 			template.find('.text-upload').on('click', function() {
@@ -259,7 +270,8 @@ define(function(require) {
 
 		bindReview: function(template, data) {
 			var self = this,
-				expectedColumns = data.columns.expected;
+				expectedColumns = data.columns.expected,
+				locationId = data.locationId || null; //? Billing Location Addition
 
 			monster.ui.footable(template.find('.footable'), {
 				filtering: {
@@ -288,10 +300,10 @@ define(function(require) {
 					if (numValidation.isValid) {
 						if (hasCustomizations) {
 							self.renderCustomizations(formattedData.data, function(customizations) {
-								self.startProcess(formattedData.data, customizations);
+								self.startProcess(formattedData.data, customizations, locationId); 
 							});
 						} else {
-							self.startProcess(formattedData.data, {});
+							self.startProcess(formattedData.data, {}, locationId);
 						}
 					// If the number validation is FALSE then generate the error message for the user.
 					} else {
@@ -427,7 +439,7 @@ define(function(require) {
 			}
 		},
 
-		createSmartPBXData: function(formattedData, customizations, onProgress) {
+		createSmartPBXData: function(formattedData, customizations, locationId, onProgress) {
 			var self = this,
 				parallelRequests = [],
 				totalRequests,
@@ -444,7 +456,7 @@ define(function(require) {
 					parallelRequests.push(function(callback) {
 						var data = self.formatUserData(record, customizations);
 
-						self.createSmartPBXUser(data, function(dataUser) {
+						self.createSmartPBXUser(data, locationId, function(dataUser) {
 							dataProgress = {
 								countFinishedRequests: countFinishedRequests++,
 								totalRequests: totalRequests
@@ -464,7 +476,26 @@ define(function(require) {
 			});
 		},
 
-		startProcess: function(data, customizations) {
+		getLocationId: function(callback) {  //? Billing Location Addition
+			var self = this;
+
+			if (monster.billing_locations) {
+				monster.pub('audian_commons.billingLocations.render', {
+					accountId: self.accountId,
+					type: 'get',
+					requestSuccessCallback: function (locationId) {
+						callback(locationId);
+					},
+					requestErrorCallback: function () {
+						callback(false);
+					}
+				});
+			} else {
+				callback(null);
+			}
+		},
+
+		startProcess: function(data, customizations, locationId) {
 			var self = this,
 				template = $(self.getTemplate({
 					name: 'progress',
@@ -477,7 +508,7 @@ define(function(require) {
 				.empty()
 				.append(template);
 
-			self.createSmartPBXData(data, customizations, function(user, progress) {
+			self.createSmartPBXData(data, customizations, locationId, function(user, progress) {
 				var percentFilled = Math.ceil((progress.countFinishedRequests / progress.totalRequests) * 100);
 				template.find('.count-requests-done').html(progress.countFinishedRequests);
 				template.find('.count-requests-total').html(progress.totalRequests);
@@ -909,7 +940,7 @@ define(function(require) {
 			return formattedData;
 		},
 
-		createSmartPBXUser: function(data, success, error) {
+		createSmartPBXUser: function(data, locationId, success, error) {
 			var self = this,
 				formattedResult = {
 					device: {},
@@ -920,6 +951,7 @@ define(function(require) {
 
 			self.callApi({
 				resource: 'user.create',
+				locationId: locationId,  //? Billing Location Addition
 				data: {
 					accountId: self.accountId,
 					data: data.user
@@ -933,13 +965,13 @@ define(function(require) {
 					data.device.owner_id = userId;
 					monster.parallel({
 						vmbox: function(callback) {
-							self.createVMBox(data.vmbox, function(_dataVM) {
+							self.createVMBox(data.vmbox, locationId, function(_dataVM) {
 								callback(null, _dataVM);
 							});
 						},
 						device: function(callback) {
 							if (data.rawData.brand && data.rawData.brand !== 'none') { //Detects if there is a valid device.
-								self.createDevice(data.device, function(_dataDevice) { //Create device
+								self.createDevice(data.device, locationId, function(_dataDevice) { //Create device
 									callback(null, _dataDevice);
 								});
 							} else {
@@ -948,7 +980,7 @@ define(function(require) {
 						},
 						softphone: function(callback) {
 							if (data.rawData.softphone === 'yes') { //Detects if the user needs a softphone
-								self.createSoftPhone(data.user, function(_dataSoftPhone) { //Create softphone
+								self.createSoftPhone(data.user, locationId, function(_dataSoftPhone) { //Create softphone
 									callback(null, _dataSoftPhone);
 								});
 							} else {
@@ -993,11 +1025,12 @@ define(function(require) {
 			});
 		},
 
-		createVMBox: function(data, callback) {
+		createVMBox: function(data, locationId, callback) {
 			var self = this;
 
 			self.callApi({
 				resource: 'voicemail.create',
+				locationId: locationId,  //? Billing Location Addition
 				data: {
 					accountId: self.accountId,
 					data: data
@@ -1023,11 +1056,12 @@ define(function(require) {
 			});
 		},
 
-		createDevice: function(data, callback) {
+		createDevice: function(data, locationId, callback) {
 			var self = this;
 
 			self.callApi({
 				resource: 'device.create',
+				locationId: locationId,  //? Billing Location Addition
 				data: {
 					accountId: self.accountId,
 					data: data
@@ -1038,7 +1072,7 @@ define(function(require) {
 			});
 		},
 
-		createSoftPhone: function(data, callback) {
+		createSoftPhone: function(data, locationId, callback) {
 			var self = this,
 				formattedDeviceData = {
 					device_type: 'softphone',
@@ -1053,6 +1087,7 @@ define(function(require) {
 
 			self.callApi({
 				resource: 'device.create',
+				locationId: locationId,  //? Billing Location Addition
 				data: {
 					accountId: self.accountId,
 					data: formattedDeviceData

--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@ define(function(require) {
 	var $ = require('jquery'),
 		_ = require('lodash'),
 		monster = require('monster'),
-		Papa = require('papaparse');
+		Papa = require('papaparse'),
+		magpieSDK = require('magpieSDK');
 
 	var app = {
 		css: ['app'],
@@ -174,16 +175,23 @@ define(function(require) {
 			});
 
 			template.find('#proceed').on('click', function() {
-				 //? Billing Location Addition
-				self.getLocationId(function(location_id) {
-					if (locationId === false) {
-						monster.ui.alert('error', 'Billing locations experienced an issue please try again.');
-						return;
-					} else {
-						locationId = location_id;
-						addJob();
-					}
-				});
+				var hasMultiLocations = _.get(monster, 'billing_locations', false);
+
+				if (!hasMultiLocations) {
+					addJob();
+				} else {
+					//? Billing Location Addition
+					self.getLocationId(function(location_id) {
+						if (location_id === false) {
+							monster.ui.alert('error', 'A location is required in order to progress. Please select a location and try again');
+							self.csvOnboardingRender();
+							return;
+						} else {
+							locationId = location_id;
+							addJob();
+						}
+					});
+				}
 			});
 
 			template.find('.text-upload').on('click', function() {
@@ -456,7 +464,7 @@ define(function(require) {
 					parallelRequests.push(function(callback) {
 						var data = self.formatUserData(record, customizations);
 
-						self.createSmartPBXUser(data, locationId, function(dataUser) {
+						self.createSmartPBXUser(data, function(dataUser) {
 							dataProgress = {
 								countFinishedRequests: countFinishedRequests++,
 								totalRequests: totalRequests
@@ -471,28 +479,124 @@ define(function(require) {
 				totalRequests = parallelRequests.length;
 
 				monster.parallel(parallelRequests, function(err, results) {
-					self.showResults(results);
+					if (results && locationId !== null) {
+						self.assignLocations(results, locationId);
+					} else {
+						self.showResults(results);
+					}
 				});
 			});
 		},
 
+		assignLocations: function(results, locationId) {
+			var self = this, 
+				userIds = [],
+				deviceIds = [],
+				vmboxIds = [],
+				numbers = [];
+
+			_.each(results, function(result) {
+				if (typeof result.user !== 'undefined' && _.isString(result.user.id)) {
+					userIds.push(result.user.id);
+				}
+
+				if (typeof result.device !== 'undefined' && _.isString(result.device.id)) {
+					deviceIds.push(result.device.id);
+				}
+
+				if (typeof result.softphone !== 'undefined' && _.isString(result.softphone.id)) {
+					deviceIds.push(result.softphone.id);
+				}
+
+				if (typeof result.vmbox !== 'undefined' && _.isString(result.vmbox.id)) {
+					vmboxIds.push(result.vmbox.id);
+				}
+
+				if (typeof result.callflow !== 'undefined' && result.callflow.numbers.length > 0) {
+					_.each(result.callflow.numbers, function(number) {
+						if (monster.util.getFormatPhoneNumber(number).isValid) {
+							numbers.push(number);
+						}
+					});
+				}
+			});
+
+			monster.parallel({
+				user: function(callback) {
+					if (userIds.length > 0) {
+						magpieSDK.assignToLocation({
+							accountId: self.accountId,
+							locationId: locationId,
+							resource: 'users',
+							data: userIds
+						}, function(data, error) {
+							callback(error ? error : null, data);
+						});
+					} else {
+						callback(null, {});
+					}
+				},
+				devices: function(callback) {
+					if (deviceIds.length > 0) {
+						magpieSDK.assignToLocation({
+							accountId: self.accountId,
+							locationId: locationId,
+							resource: 'devices',
+							data: deviceIds
+						}, function(data, error) {
+							callback(error ? error : null, data);
+						});
+					} else {
+						callback(null, {});
+					}
+				},
+				numbers: function(callback) {
+					if (numbers.length > 0) {
+						magpieSDK.assignToLocation({
+							accountId: self.accountId,
+							locationId: locationId,
+							resource: 'numbers',
+							data: numbers
+						}, function(data, error) {
+							callback(error ? error : null, data);
+						});
+					} else {
+						callback(null, {});
+					}
+				},
+				vmbox: function(callback) {
+					if (vmboxIds.length > 0) {
+						magpieSDK.assignToLocation({
+							accountId: self.accountId,
+							locationId: locationId,
+							resource: 'vmbox',
+							data: vmboxIds
+						}, function(data, error) {
+							callback(error ? error : null, data);
+						});
+					} else {
+						callback(null, {});
+					}
+				},
+			}, function(err, magpie_results) {
+				self.showResults(results);
+			});
+		},
+
+		//? Get the billing location ID by rendering the location selection popup.
 		getLocationId: function(callback) {  //? Billing Location Addition
 			var self = this;
 
-			if (monster.billing_locations) {
-				monster.pub('audian_commons.billingLocations.render', {
-					accountId: self.accountId,
-					type: 'get',
-					requestSuccessCallback: function (locationId) {
-						callback(locationId);
-					},
-					requestErrorCallback: function () {
-						callback(false);
-					}
-				});
-			} else {
-				callback(null);
-			}
+			monster.pub('audian_commons.billingLocations.render', {
+				accountId: self.accountId,
+				type: 'get',
+				requestSuccessCallback: function (data) {
+					callback(data.data.locationId);
+				},
+				requestErrorCallback: function () {
+					callback(false);
+				}
+			});
 		},
 
 		startProcess: function(data, customizations, locationId) {
@@ -558,28 +662,7 @@ define(function(require) {
 
 		showResults: function(results) {
 			var self = this;
-			/*var self = this,
-				parent = $('#csv_onboarding_app_container'),
-				template = $(self.getTemplate({
-					name: 'results',
-					data: results
-				}));
 
-			monster.ui.footable(template.find('.footable'));
-
-			parent.find('.content-wrapper')
-					.empty()
-					.append(template);*/
-
-			/*{
-				provision: {
-					combo_keys: {
-						0: {type: "line"},
-						1: {type: "parking", value: "1"},
-						2: {type: "parking", value: "2"}
-					}
-				}
-			}*/
 			monster.ui.toast({
 				type: 'success',
 				message: 'Congratulations, you successfully imported data to this account!'
@@ -940,7 +1023,7 @@ define(function(require) {
 			return formattedData;
 		},
 
-		createSmartPBXUser: function(data, locationId, success, error) {
+		createSmartPBXUser: function(data, success, error) {
 			var self = this,
 				formattedResult = {
 					device: {},
@@ -951,7 +1034,7 @@ define(function(require) {
 
 			self.callApi({
 				resource: 'user.create',
-				locationId: locationId,  //? Billing Location Addition
+				skipLocations: true,
 				data: {
 					accountId: self.accountId,
 					data: data.user
@@ -965,13 +1048,13 @@ define(function(require) {
 					data.device.owner_id = userId;
 					monster.parallel({
 						vmbox: function(callback) {
-							self.createVMBox(data.vmbox, locationId, function(_dataVM) {
+							self.createVMBox(data.vmbox, function(_dataVM) {
 								callback(null, _dataVM);
 							});
 						},
 						device: function(callback) {
 							if (data.rawData.brand && data.rawData.brand !== 'none') { //Detects if there is a valid device.
-								self.createDevice(data.device, locationId, function(_dataDevice) { //Create device
+								self.createDevice(data.device, function(_dataDevice) { //Create device
 									callback(null, _dataDevice);
 								});
 							} else {
@@ -980,7 +1063,7 @@ define(function(require) {
 						},
 						softphone: function(callback) {
 							if (data.rawData.softphone === 'yes') { //Detects if the user needs a softphone
-								self.createSoftPhone(data.user, locationId, function(_dataSoftPhone) { //Create softphone
+								self.createSoftPhone(data.user, function(_dataSoftPhone) { //Create softphone
 									callback(null, _dataSoftPhone);
 								});
 							} else {
@@ -1025,12 +1108,12 @@ define(function(require) {
 			});
 		},
 
-		createVMBox: function(data, locationId, callback) {
+		createVMBox: function(data, callback) {
 			var self = this;
 
 			self.callApi({
 				resource: 'voicemail.create',
-				locationId: locationId,  //? Billing Location Addition
+				skipLocations: true,
 				data: {
 					accountId: self.accountId,
 					data: data
@@ -1056,12 +1139,12 @@ define(function(require) {
 			});
 		},
 
-		createDevice: function(data, locationId, callback) {
+		createDevice: function(data, callback) {
 			var self = this;
 
 			self.callApi({
 				resource: 'device.create',
-				locationId: locationId,  //? Billing Location Addition
+				skipLocations: true,
 				data: {
 					accountId: self.accountId,
 					data: data
@@ -1072,7 +1155,7 @@ define(function(require) {
 			});
 		},
 
-		createSoftPhone: function(data, locationId, callback) {
+		createSoftPhone: function(data, callback) {
 			var self = this,
 				formattedDeviceData = {
 					device_type: 'softphone',
@@ -1087,7 +1170,7 @@ define(function(require) {
 
 			self.callApi({
 				resource: 'device.create',
-				locationId: locationId,  //? Billing Location Addition
+				skipLocations: true,
 				data: {
 					accountId: self.accountId,
 					data: formattedDeviceData


### PR DESCRIPTION
- Added Magpie SDK
- Added a check if billing_locations is enabled and if so then use the billing locations commons to display a popup to get a location ID. Then after the CSV app has created all the assets it will assign all the resources to magpie.
- Added a locations middleware bypass to the create API calls so that the location selection popup and setter logic are skipped. The setter logic is handled in the CSV app.